### PR TITLE
Add docs index page for browsing LLM phylogeny figures

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,130 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>LLM Phylogeny Figures</title>
+  <style>
+    :root {
+      color-scheme: light dark;
+      font-family: system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+      background-color: Canvas;
+      color: CanvasText;
+    }
+
+    body {
+      margin: 0 auto;
+      max-width: 1000px;
+      padding: 2rem 1rem 3rem;
+      line-height: 1.6;
+    }
+
+    header {
+      margin-bottom: 1.5rem;
+    }
+
+    h1 {
+      margin-bottom: 0.25rem;
+      font-size: clamp(2rem, 5vw, 2.75rem);
+    }
+
+    p {
+      margin-top: 0.5rem;
+      margin-bottom: 1rem;
+      max-width: 70ch;
+    }
+
+    label {
+      display: block;
+      font-weight: 600;
+      margin-bottom: 0.5rem;
+    }
+
+    select {
+      font-size: 1rem;
+      padding: 0.5rem;
+      width: 100%;
+      max-width: 22rem;
+      border-radius: 0.375rem;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+    }
+
+    iframe {
+      margin-top: 1.5rem;
+      width: 100%;
+      min-height: 70vh;
+      border: 1px solid rgba(0, 0, 0, 0.15);
+      border-radius: 0.5rem;
+    }
+
+    noscript {
+      display: block;
+      margin-top: 1.5rem;
+      padding: 1rem;
+      border: 1px solid rgba(0, 0, 0, 0.2);
+      border-radius: 0.5rem;
+      background-color: rgba(0, 0, 0, 0.05);
+    }
+
+    .links {
+      margin-top: 1rem;
+      padding-left: 1.2rem;
+    }
+
+    .links li + li {
+      margin-top: 0.35rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>LLM Phylogeny Figures</h1>
+    <p>
+      Use the selector below to browse the available LLM phylogeny visualisations.
+      The figures will load inline on this page. If you prefer, you can also open
+      each figure in a dedicated tab using the quick links provided.
+    </p>
+  </header>
+
+  <section>
+    <label for="figure-select">Choose a figure to view:</label>
+    <select id="figure-select" aria-label="LLM phylogeny figure selector">
+      <option value="interactive_llm_phylogeny.html">Interactive LLM Phylogeny</option>
+      <option value="genome_llm_phylogeny.html">Genome LLM Phylogeny</option>
+      <option value="protein_llm_phylogeny.html">Protein LLM Phylogeny</option>
+      <option value="small_molecule_llm_phylogeny.html">Small Molecule LLM Phylogeny</option>
+    </select>
+
+    <iframe
+      id="figure-frame"
+      title="Selected LLM phylogeny figure"
+      src="interactive_llm_phylogeny.html"
+      loading="lazy"
+    ></iframe>
+
+    <noscript>
+      JavaScript is required to show the figures on this page. Use the links below to
+      open each figure individually.
+    </noscript>
+
+    <ul class="links">
+      <li><a href="interactive_llm_phylogeny.html">Interactive LLM Phylogeny</a></li>
+      <li><a href="genome_llm_phylogeny.html">Genome LLM Phylogeny</a></li>
+      <li><a href="protein_llm_phylogeny.html">Protein LLM Phylogeny</a></li>
+      <li><a href="small_molecule_llm_phylogeny.html">Small Molecule LLM Phylogeny</a></li>
+    </ul>
+  </section>
+
+  <script>
+    const figureSelect = document.getElementById('figure-select');
+    const figureFrame = document.getElementById('figure-frame');
+
+    figureSelect.addEventListener('change', (event) => {
+      const nextSrc = event.target.value;
+      if (nextSrc && figureFrame.getAttribute('src') !== nextSrc) {
+        figureFrame.setAttribute('src', nextSrc);
+      }
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a GitHub Pages compatible index page to the docs directory
- provide a dropdown selector and iframe viewer to switch between the available phylogeny figures
- include direct links for users without JavaScript support

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e403f827d88331b933b188bd95f824